### PR TITLE
Improve notificationspermissionstext

### DIFF
--- a/browser/chrome/browser/preferences/preferences.properties
+++ b/browser/chrome/browser/preferences/preferences.properties
@@ -25,7 +25,7 @@ addons_permissions_title=Uprawnione witryny - Instalacja dodatków
 popuppermissionstext=Określ, które witryny mogą otwierać wyskakujące okna. Podaj dokładny adres witryny, której chcesz na to zezwolić, i naciśnij Zezwalaj.
 popuppermissionstitle=Uprawnione witryny - Wyskakujące okna
 
-notificationspermissionstext=Określ, które witryny mogą wyświetlać powiadomienia a które nie. Podaj dokładny adres witryny, której uprawnienia chcesz określić i naciśnij Blokuj lub Zezwalaj.
+notificationspermissionstext=Określ, które witryny mogą wyświetlać powiadomienia. Podaj dokładny adres witryny, której uprawnienia chcesz określić i naciśnij Blokuj lub Zezwalaj.
 notificationspermissionstitle=Uprawnione witryny - Powiadomienia
 
 invalidURI=Podaj poprawną nazwę hosta


### PR DESCRIPTION
At first I just wanted to add a missing comma before "a które nie", but then I figured "Określ, które witryny mogą wyświetlać powiadomienia" is simpler, a little bit less clunky, and still perfectly understandable.
