### PR TITLE
Better translation of "authorization" in suite

### DIFF
--- a/suite/chrome/mailnews/news.properties
+++ b/suite/chrome/mailnews/news.properties
@@ -54,7 +54,7 @@ autoSubscribeText=Czy subskrybować %1$S?
 # Error - NNTP authinfo failure
 ## @name NNTP_AUTH_FAILED
 ## @loc None
--260=Wystąpił błąd autoryzacji. Spróbuj wpisać ponownie nazwę użytkownika i/lub hasło.
+-260=Wystąpił błąd podczas upoważniania. Spróbuj wpisać ponownie nazwę użytkownika i/lub hasło.
 
 # Error - TCP error
 ## @name TCP_ERROR


### PR DESCRIPTION
From the calque "autoryzować" to more Polish "upoważniać". In line with PR#17.

@adrianer
