### PR TITLE
Unify "support" translation to "obsługiwać" in one more place

### DIFF
--- a/webapprt/webapprt/webapp.properties
+++ b/webapprt/webapprt/webapp.properties
@@ -30,6 +30,6 @@ paymentDialog.title=Płatność
 paymentDialog.message=Którego pośrednika płatności wybrać?
 
 disable-warning.title=Ostrzeżenie: aplikacja zostanie wyłączona
-disable-warning.description=Ta aplikacja zostanie wyłączona po aktualizacji Firefoksa do nowszej wersji, nie wspierającej już uruchamiania aplikacji internetowych oddzielnie od przeglądarki.
+disable-warning.description=Ta aplikacja zostanie wyłączona po aktualizacji Firefoksa do nowszej wersji, nieobsługującej już uruchamiania aplikacji internetowych oddzielnie od przeglądarki.
 disable-warning.info.label=Więcej informacji…
 disable-warning.show-again=Wyświetlanie ostrzeżenia przy uruchamianiu aplikacji


### PR DESCRIPTION
I hasted to close/delete PR #72 before I noticed the comment, so here is another one.
